### PR TITLE
feat: Add retry for faucet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN wget https://github.com/warden-protocol/wardenprotocol/releases/download/v0.
     && unzip /tmp/wardend.zip -d ./ \
     && rm /tmp/wardend.zip
 
-#FROM gcr.io/distroless/base-debian12:nonroot
 FROM ubuntu:22.04
 
 RUN apt-get update && apt-get install -y \
@@ -21,4 +20,3 @@ COPY discord-faucet /usr/bin/discord-faucet
 COPY --from=wardend /wardend /usr/bin/wardend
 
 CMD ["/usr/bin/discord-faucet"]
-#ENTRYPOINT ["ls", "-la", "/usr/bin"]

--- a/pkg/discord/discord.go
+++ b/pkg/discord/discord.go
@@ -92,7 +92,7 @@ func (d *Discord) requestFunds(m *discordgo.MessageCreate) {
 	}
 
 	var returnMsg string
-	tx, err := d.Faucet.Send(addr)
+	tx, err := d.Faucet.Send(addr, 1)
 	if err != nil {
 		d.logger.Error().Err(err).Msgf("failed to send funds to %s", addr)
 		returnMsg = fmt.Sprintf(":red_circle: %s", err)


### PR DESCRIPTION
This will add new functionality that adds retries for the sending TXs.
It tries configurable amount TX_RETRY * waitTime (2s) if getting account sequence errors.