### PR TITLE
fix: update wardend to support new version of wardend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y \
     unzip \
     && rm -rf /var/lib/apt/lists/*
 
-RUN wget https://github.com/warden-protocol/wardenprotocol/releases/download/v0.3.0/wardend_Linux_x86_64.zip -O /tmp/wardend.zip \
+RUN wget https://github.com/warden-protocol/wardenprotocol/releases/download/v0.5.0/wardend_Linux_x86_64.zip -O /tmp/wardend.zip \
     && unzip /tmp/wardend.zip -d ./ \
     && rm /tmp/wardend.zip
 

--- a/pkg/faucet/faucet.go
+++ b/pkg/faucet/faucet.go
@@ -160,9 +160,8 @@ func (f *Faucet) Send(addr string, retry int) (string, error) {
 		}
 	}
 
-	f.Logger.Info().Msgf("sending %s%s to %v", f.Amount, f.Denom, addr)
-
 	amount := f.Amount + strings.Repeat("0", f.Decimals) + f.Denom
+	f.Logger.Info().Msgf("sending %s to %v", amount, addr)
 
 	cmd := strings.Join([]string{
 		f.CliName,


### PR DESCRIPTION
this will fix the errors in sending tokens with the old version of the wardend which is not compatible with the new chain